### PR TITLE
Documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,8 @@ arma3/*
 !arma3/mpmissions
 arma3/mpmissions/*.pbo
 !arma3/configs
+!arma3/configs/basic.cfg.example
 arma3/configs/*
-!arma3/configs/basic.cfg
 !arma3/steamapps
 arma3/steamapps/*
 !arma3/steamapps/workshop
@@ -17,4 +17,3 @@ arma3/mods/*
 !arma3/servermods
 arma3/servermods/*
 /steam
-Pipfile*

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ We removed the need to statically pass in the password via env vars, and accomod
 
 ### docker-compose
 
-Use the docker-compose.yml file inside a folder. It will automatically create 4 folders in which the missions, configs, mods and servermods can be loaded.
+Use the docker-compose.yml file inside a folder. It will automatically create an "arma3" folder in which the missions, configs, mods and servermods can be loaded into their respective subfolders.
 
 Copy the `.env.example` file to `.env`, containing at least `STEAM_USER`.
 

--- a/README.md
+++ b/README.md
@@ -112,4 +112,6 @@ Set the environment variable `MODS_PRESET` to the HTML preset file exported from
 
 ## Discord bot
 
-To use the discord bot and get status updates in your preferred server and channel, you need to create an Application in Discords [Developer Portal](https://discord.com/developers/applications). After doing so you need to create a bot for that application and copy the created Token into your .envs `DISCORD_TOKEN`. Now head over to `OAuth2\URL Generator` and create a URL asking for `bot` permissions `Read Messages/View Channels`, `Send Messages` and `Manage Messages`. Via the generated url you can now invite the bot to your preferred server.
+To use the discord bot and get status updates in your preferred server and channel, you need to create an Application in Discords [Developer Portal](https://discord.com/developers/applications). 
+After doing so you need to create a bot for that application and copy the created Token into your .envs `DISCORD_TOKEN`. Now head over to `OAuth2\URL Generator` and create a URL asking for `bot` permissions `Read Messages/View Channels`, `Send Messages` and `Manage Messages`. 
+Via the generated url you can now invite the bot to your preferred server, check out the provided functions using `!help`

--- a/README.md
+++ b/README.md
@@ -113,5 +113,7 @@ Set the environment variable `MODS_PRESET` to the HTML preset file exported from
 ## Discord bot
 
 To use the discord bot and get status updates in your preferred server and channel, you need to create an Application in Discords [Developer Portal](https://discord.com/developers/applications). 
+
 After doing so you need to create a bot for that application and copy the created Token into your .envs `DISCORD_TOKEN`. Now head over to `OAuth2\URL Generator` and create a URL asking for `bot` permissions `Read Messages/View Channels`, `Send Messages` and `Manage Messages`. 
+
 Via the generated url you can now invite the bot to your preferred server, check out the provided functions using `!help`

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Use the docker-compose.yml file inside a folder. It will automatically create an
 
 Copy the `.env.example` file to `.env`, containing at least `STEAM_USER`.
 
+Rename `arma3/configs/main.cfg.example` to `main.cfg` and configure it to your liking.
+
 Use `docker-compose start` to start the server.
 
 Use `docker-compose logs` to see server logs.
@@ -107,3 +109,7 @@ Set the environment variable `MODS_PRESET` to the HTML preset file exported from
 `-e MODS_PRESET="my_mods.html"`
 
 `-e MODS_PRESET="http://example.com/my_mods.html"`
+
+## Discord bot
+
+To use the discord bot and get status updates in your preferred server and channel, you need to create an Application in Discords [Developer Portal](https://discord.com/developers/applications). After doing so you need to create a bot for that application and copy the created Token into your .envs `DISCORD_TOKEN`. Now head over to `OAuth2\URL Generator` and create a URL asking for `bot` permissions `Read Messages/View Channels`, `Send Messages` and `Manage Messages`. Via the generated url you can now invite the bot to your preferred server.

--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ Profiles are saved in `/arma3/configs/profiles`
 | `-e MODS_PRESET`              | An Arma 3 Launcher preset to load |
 | `-e BASIC_CONFIG`             | Basic config file to load from `arma3/configs`            |`basic.cfg` |
 
-List of Steam branches can be found on the Community Wiki, [Arma 3: Steam Branches](https://community.bistudio.com/wiki/Arma_3:_Steam_Branches)
+List of Steam branches can be found on the Community Wiki, [Arma 3: Steam Branches](https://community.bistudio.com/wiki/Arma_3:_Steam_Branches).
+
+If you change the steamPort in `main.cfg` to something non-default change your docker ports command according to [this](https://community.bistudio.com/wiki/Arma_3:_Dedicated_Server#Port_Forwarding) official wiki entry.
 
 ## Creator DLC
 

--- a/README.md
+++ b/README.md
@@ -12,19 +12,13 @@ We removed the need to statically pass in the password via env vars, and accomod
 
 ```s
     docker create \
-        --name=arma-server \
         -p 2302:2302/udp \
         -p 2303:2303/udp \
         -p 2304:2304/udp \
         -p 2305:2305/udp \
         -p 2306:2306/udp \
-        -v path/to/missions:/arma3/mpmissions \
-        -v path/to/configs:/arma3/configs \
-        -v path/to/mods:/arma3/mods \
-        -v path/to/servermods:/arma3/servermods \
-        -e ARMA_CONFIG=main.cfg \
-        -e STEAM_USER=myusername \
-        -e ARMA_BASIC=basic.cfg \
+        -v path/to/arma3:/arma3/ \
+        --env-file ".env"
         ghcr.io/mylesagray/arma3-server
 ```
 
@@ -32,7 +26,7 @@ We removed the need to statically pass in the password via env vars, and accomod
 
 Use the docker-compose.yml file inside a folder. It will automatically create 4 folders in which the missions, configs, mods and servermods can be loaded.
 
-Copy the `.env.example` file to `.env`, containing at least `STEAM_USER` and `STEAM_PASSWORD`.
+Copy the `.env.example` file to `.env`, containing at least `STEAM_USER`.
 
 Use `docker-compose start` to start the server.
 
@@ -53,10 +47,7 @@ Profiles are saved in `/arma3/configs/profiles`
 | Parameter                     | Function                                                  | Default |
 | -------------                 |--------------                                             | - |
 | `-p 2302-2306`                | Ports required by Arma 3 |
-| `-v /arma3/mpmission`         | Folder with MP Missions |
-| `-v /arma3/configs`           | Folder containing config files |
-| `-v /arma3/mods`              | Mods that will be loaded by clients |
-| `-v /arma3/servermods`        | Mods that will only be loaded by the server |
+| `-v /arma3`                   | Folder containing Arma 3 files |
 | `-e PORT`                     | Port used by the server, (uses PORT to PORT+3)            | 2302 |
 | `-e ARMA_BINARY`              | Arma 3 server binary to use, `./arma3server_x64` for x64   | `./arma3server` |
 | `-e ARMA_CONFIG`              | Config file to load from `/arma3/configs`                 | `main.cfg` |
@@ -99,7 +90,7 @@ There is a bug in the S.O.G. Prairie Fire CDLC which causes headless clients to 
 
 ### Local
 
-1. Place the mods inside `/mods` or `/servermods`.
+1. Place the mods inside `arma3/mods` or `arma3/servermods`.
 2. Be sure that the mod folder is all lowercase and does not show up with quotation marks around it when listing the directory eg `'@ACE(v2)'`
 3. Run the following command from the mods and/or servermods directory to confirm that all the files are lowercase.
     `find . -depth -exec rename 's/(.*)\/([^\/]*)/$1\/\L$2/' {} \;`
@@ -109,7 +100,7 @@ There is a bug in the S.O.G. Prairie Fire CDLC which causes headless clients to 
 
 ### Workshop
 
-Set the environment variable `MODS_PRESET` to the HTML preset file exported from the Arma 3 Launcher. The path can be local file or a URL. A volume can be created at `/arma3/steamapps/workshop/content/107410` to preserve the mods between containers.
+Set the environment variable `MODS_PRESET` to the HTML preset file exported from the Arma 3 Launcher. The path can be local file or a URL.
 
 `-e MODS_PRESET="my_mods.html"`
 

--- a/README.md
+++ b/README.md
@@ -116,4 +116,4 @@ To use the discord bot and get status updates in your preferred server and chann
 
 After doing so you need to create a bot for that application and copy the created Token into your .envs `DISCORD_TOKEN`. Now head over to `OAuth2\URL Generator` and create a URL asking for `bot` permissions `Read Messages/View Channels`, `Send Messages` and `Manage Messages`. 
 
-Via the generated url you can now invite the bot to your preferred server, check out the provided functions using `!help`
+Via the generated url you can now invite the bot to your preferred server, check out the provided functions using `!help

--- a/README.md
+++ b/README.md
@@ -11,14 +11,16 @@ We removed the need to statically pass in the password via env vars, and accomod
 ### Docker CLI
 
 ```s
-    docker create \
+    docker run \
+        --name arma3server \
         -p 2302:2302/udp \
         -p 2303:2303/udp \
         -p 2304:2304/udp \
         -p 2305:2305/udp \
         -p 2306:2306/udp \
         -v path/to/arma3:/arma3/ \
-        --env-file ".env"
+        --env-file ".env" \
+        --restart unless-stopped \
         ghcr.io/mylesagray/arma3-server
 ```
 

--- a/app/bot.py
+++ b/app/bot.py
@@ -19,8 +19,11 @@ except:
     print("Missing token")
     exit()
 
+
 DISCORD_CONFIG = "/arma3/configs/discord.cfg"
 
+# tries to load an existing DISCORD_CONFIG, creates one on initial startup. 
+# Fails if the path isn't writeable
 def load_settings():
     try:
         f = open(DISCORD_CONFIG,'r')
@@ -51,11 +54,16 @@ def save_settings(jsonString):
     return 1
 
 desc = '''Arma3 server status bot:
-!setup - add this channel to update notification list
-!delete - removes this channel from update notification list'''
+!setup - Adds a message to this channel that will be updated by !update //TODO: implement cron feature
+!delete - Removes the message created by !setup
+!status - Sends a self deleting status message with all available server info
+!update - Updates the pinned message from !setup
+!mods - Sends a self deleting message with the currently used mod-list as html file
+!ping - Alive check'''
 
 bot = commands.Bot(command_prefix='!', description=desc)
 
+# mostly for debugging purposes
 @bot.command(name="get")
 async def _get(ctx, arg):
     response = desc
@@ -65,6 +73,7 @@ async def _get(ctx, arg):
         response = update.get_install_state()
     await ctx.send(response)
 
+# Adds a message to the channel that it was executed in, pins it and stores the id for !update
 @bot.command(name="setup")
 async def _setup(ctx, *arg):
     response = ""
@@ -90,13 +99,15 @@ async def _setup(ctx, *arg):
     res = await ctx.send(response)
     if res.id not in settings["DISCORD_SERVER"][server]["msgids"]:
         settings["DISCORD_SERVER"][server]["msgids"].append(res.id)
-        #bot.get_channel(channel).fetch_message(res.id).pin()
+        ctx.channel.pin(res)
     res = save_settings(settings)
     if not res:
         response = "Saving the settings failed, call an adult"
         ctx.send(response)
+    if res:
+        _update()
 
-
+# Removes the channel this was called in from the list of channels to !update
 @bot.command(name="delete")
 async def _delete(ctx, *arg):
     response = "Channel not monitored"
@@ -118,13 +129,14 @@ async def _delete(ctx, *arg):
         response = "Saving the settings failed, call an adult"
     await ctx.send(response)
 
-
+# updates the pinned messages created via !setup
 @bot.command(name="update")
 async def _update(ctx, *args):
     response = ""
     # No servers configured = no need to process further
     if "DISCORD_SERVER" not in settings:
         return
+    await ctx.message.delete()
     cnt = 0
     embed = messageConstructor()
     for server in settings["DISCORD_SERVER"]:
@@ -134,19 +146,20 @@ async def _update(ctx, *args):
             message = await chan.fetch_message(settings["DISCORD_SERVER"][server]["msgids"][cnt])
             await message.edit(content="",embed=embed)
             cnt += 1
-    await ctx.message.delete()
 
+# Sends a self deleting status message with all available server info
 @bot.command(name="status")
 async def _status(ctx, *args):
-    embed = messageConstructor()
     await ctx.message.delete()
+    embed = messageConstructor()
     await ctx.send(content="(delete in 60sec)", embed=embed, delete_after=60)
     
-
+# Alive check
 @bot.command(name="ping")
 async def _ping(ctx, *args):
     await ctx.send("pong 🏓")
 
+# Sends a self deleting message with the currently used mod-list as html file
 @bot.command(name="mods")
 async def _mods(ctx, *args):
     await ctx.message.delete()
@@ -162,7 +175,7 @@ async def _mods(ctx, *args):
     else:
         await ctx.send("No mod file defined, maybe you're running non-workshop mods?")
 
-# returns the embed that we send
+# Constructs an embed for !update and !status
 def messageConstructor():
     status = update.get_install_state()
     version = update.get_version()

--- a/app/bot.py
+++ b/app/bot.py
@@ -17,7 +17,7 @@ if not env_defined("DISCORD_TOKEN"):
     print("Missing bot token from .env")
     exit()
 
-
+DISCORD_TOKEN=os.environ["DISCORD_TOKEN"]
 DISCORD_CONFIG = "/arma3/configs/discord.cfg"
 
 # tries to load an existing DISCORD_CONFIG, creates one on initial startup. 

--- a/app/bot.py
+++ b/app/bot.py
@@ -13,10 +13,8 @@ def env_defined(key):
 DISCORD_CHANNEL = []
 # env variables are defaults, if no config file exists it'll be created.
 # If no env is set, stop the bot
-try:
-    DISCORD_TOKEN = os.environ["DISCORD_TOKEN"]
-except:
-    print("Missing token")
+if not env_defined("DISCORD_TOKEN"):
+    print("Missing bot token from .env")
     exit()
 
 

--- a/app/bot.py
+++ b/app/bot.py
@@ -97,13 +97,13 @@ async def _setup(ctx, *arg):
     res = await ctx.send(response)
     if res.id not in settings["DISCORD_SERVER"][server]["msgids"]:
         settings["DISCORD_SERVER"][server]["msgids"].append(res.id)
-        ctx.channel.pin(res)
+        await res.pin()
     res = save_settings(settings)
     if not res:
         response = "Saving the settings failed, call an adult"
-        ctx.send(response)
+        await ctx.send(response)
     if res:
-        _update()
+        await _update(ctx)
 
 # Removes the channel this was called in from the list of channels to !update
 @bot.command(name="delete")

--- a/app/launch.py
+++ b/app/launch.py
@@ -28,7 +28,7 @@ if not os.path.isdir(KEYS):
         os.remove(KEYS)
     os.makedirs(KEYS)
 
-# check if there's a userdata folder other than anonymous, if it exists there  is login data,
+# check if there's a userdata folder other than anonymous, if it exists there is login data,
 # if not this script will NOT try to log in further until you log in manually
 # this is required for proper 2FA and also to never store your password in ENV
 

--- a/arma3/configs/main.cfg.example
+++ b/arma3/configs/main.cfg.example
@@ -1,0 +1,15 @@
+//
+// More information at: http://community.bistudio.com/wiki/server.cfg
+//
+
+// STEAM PORTS
+steamPort = 2304;
+steamQueryPort = 2303;
+
+// GLOBAL SETTINGS
+hostname = "hostname"; // The name of the server that shall be displayed in the public server list
+password = "password"; // Password for joining, eg connecting to the server
+passwordAdmin = "passwordAdmin"; // Password to become server admin. When you're in Arma MP and connected to the server, type '#login xyz'
+serverCommandPassword = "";
+admins[] = {"123"}; //add arma3 profile id to add default admins
+logFile = "server_console.log"; // Tells ArmA-server where the logfile should go and what it should be called

--- a/arma3/configs/main.cfg.example
+++ b/arma3/configs/main.cfg.example
@@ -3,8 +3,7 @@
 //
 
 // STEAM PORTS
-steamPort = 2304;
-steamQueryPort = 2303;
+steamPort = 2302;
 
 // GLOBAL SETTINGS
 hostname = "hostname"; // The name of the server that shall be displayed in the public server list

--- a/arma3/configs/main.cfg.example
+++ b/arma3/configs/main.cfg.example
@@ -13,3 +13,7 @@ passwordAdmin = "passwordAdmin"; // Password to become server admin. When you're
 serverCommandPassword = "";
 admins[] = {"123"}; //add arma3 profile id to add default admins
 logFile = "server_console.log"; // Tells ArmA-server where the logfile should go and what it should be called
+
+
+// If you want to play with mods, BattlEye can and probably will break your game
+// BattlEye=0;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,16 @@ services:
     image: ghcr.io/mylesagray/arma3-server:latest
     ports:
         - "2302:2302/udp" 
-        - "2303:2303/udp"
-        - "2304:2304/udp"
+        - "2303:2303/udp" # Arma Server STEAM query port 
+        - "2304:2304/udp" # Arma Server to STEAM master traffic
         - "2305:2305/udp"
         - "2306:2306/udp"
+        # Uncomment if you want to use BattlEye
+        # - "2344:2344" # BattlEye - arma31.battleye.com 
+        # - "2345:2345/tcp" # BattlEye - arma31.battleye.com 
     volumes:
       - './arma3:/arma3'
       # Uncomment if you want to persistently store login data
-      #- './userdata:/home/steam/Steam'
+      # - './userdata:/home/steam/Steam'
     env_file: .env
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,15 @@ version: '3.7'
 services:
   arma3:
     image: ghcr.io/mylesagray/arma3-server:latest
-    network_mode: host
+    ports:
+        - "2302:2302/udp" 
+        - "2303:2303/udp"
+        - "2304:2304/udp"
+        - "2305:2305/udp"
+        - "2306:2306/udp"
     volumes:
       - './arma3:/arma3'
+      # Uncomment if you want to persistently store login data
+      #- './userdata:/home/steam/Steam'
     env_file: .env
     restart: unless-stopped


### PR DESCRIPTION
- Adds and/or modifies comments
- changes the initial check if DISCORD_TOKEN is provided via .env from a try/catch block to an actual check if it exists
- `!setup` now creates a message, pins and automatically updates it 
- provided a default main.cfg.example
- change docker networking from host to only exposing necessary ports
- changed readme documentation to what's currently implemented
- added bot setup to readme