### PR TITLE
Standalone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM cm2network/steamcmd:root
+FROM debian:buster-slim
 
 LABEL org.opencontainers.image.authors="Myles Gray, Florian Linke"
 LABEL org.opencontainers.image.source='https://github.com/mylesagray/arma3server'
@@ -22,20 +22,44 @@ ENV PUID=1000 \
     STEAM_APPDIR="/arma3" \
     MODS_LOCAL=true \
     MODS_PRESET= \
-    USER=steam \
-    HOMEDIR="/home/${USER}" \
-    STEAMCMDDIR="${HOMEDIR}/steamcmd"
+    USER="steam" \
+    HOMEDIR="/home/steam" \
+    STEAMCMDDIR="/home/steam/steamcmd"
 
 RUN set -x \
+	&& dpkg --add-architecture i386 \
     && apt-get update \
     && apt-get install -y --no-install-recommends --no-install-suggests \
+        build-essential \
+		ca-certificates \
+		curl \
+        lib32stdc++6 \
+		lib32gcc1 \
+		libsdl2-2.0-0:i386 \
+		locales \
+		nano \
         python3 \
         python3-dev \
         python3-pip \
-        lib32gcc-s1 \
-        build-essential \
         rename \
+		wget \
+    && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
+    && dpkg-reconfigure --frontend=noninteractive locales \
+    && printenv \
+    && useradd -u "${PUID}" -m "${USER}" \
+	&& su "${USER}" -c \
+                "mkdir -p \"${STEAMCMDDIR}\" \
+                && wget -qO- 'https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz' | tar xvzf - -C \"${STEAMCMDDIR}\" \
+                && \"./${STEAMCMDDIR}/steamcmd.sh\" +quit \
+                && mkdir -p \"${HOMEDIR}/.steam/sdk32\" \
+                && ln -s \"${STEAMCMDDIR}/linux32/steamclient.so\" \"${HOMEDIR}/.steam/sdk32/steamclient.so\" \
+                && ln -s \"${STEAMCMDDIR}/linux32/steamcmd\" \"${STEAMCMDDIR}/linux32/steam\" \
+                && ln -s \"${STEAMCMDDIR}/steamcmd.sh\" \"${STEAMCMDDIR}/steam.sh\"" \
+	&& ln -s "${STEAMCMDDIR}/linux32/steamclient.so" "/usr/lib/i386-linux-gnu/steamclient.so" \
+	&& ln -s "${STEAMCMDDIR}/linux64/steamclient.so" "/usr/lib/x86_64-linux-gnu/steamclient.so" \
     && apt-get remove --purge -y \
+        wget \
+        curl \
     && apt-get clean autoclean \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,27 +27,27 @@ ENV PUID=1000 \
     STEAMCMDDIR="/home/steam/steamcmd"
 
 RUN set -x \
-	&& dpkg --add-architecture i386 \
+    && dpkg --add-architecture i386 \
     && apt-get update \
     && apt-get install -y --no-install-recommends --no-install-suggests \
         build-essential \
-		ca-certificates \
-		curl \
+        ca-certificates \
+        curl \
         lib32stdc++6 \
-		lib32gcc1 \
-		libsdl2-2.0-0:i386 \
-		locales \
-		nano \
+        lib32gcc1 \
+        libsdl2-2.0-0:i386 \
+        locales \
+        nano \
         python3 \
         python3-dev \
         python3-pip \
         rename \
-		wget \
+        wget \
     && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
     && dpkg-reconfigure --frontend=noninteractive locales \
     && printenv \
     && useradd -u "${PUID}" -m "${USER}" \
-	&& su "${USER}" -c \
+    && su "${USER}" -c \
                 "mkdir -p \"${STEAMCMDDIR}\" \
                 && wget -qO- 'https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz' | tar xvzf - -C \"${STEAMCMDDIR}\" \
                 && \"./${STEAMCMDDIR}/steamcmd.sh\" +quit \
@@ -55,8 +55,8 @@ RUN set -x \
                 && ln -s \"${STEAMCMDDIR}/linux32/steamclient.so\" \"${HOMEDIR}/.steam/sdk32/steamclient.so\" \
                 && ln -s \"${STEAMCMDDIR}/linux32/steamcmd\" \"${STEAMCMDDIR}/linux32/steam\" \
                 && ln -s \"${STEAMCMDDIR}/steamcmd.sh\" \"${STEAMCMDDIR}/steam.sh\"" \
-	&& ln -s "${STEAMCMDDIR}/linux32/steamclient.so" "/usr/lib/i386-linux-gnu/steamclient.so" \
-	&& ln -s "${STEAMCMDDIR}/linux64/steamclient.so" "/usr/lib/x86_64-linux-gnu/steamclient.so" \
+    && ln -s "${STEAMCMDDIR}/linux32/steamclient.so" "/usr/lib/i386-linux-gnu/steamclient.so" \
+    && ln -s "${STEAMCMDDIR}/linux64/steamclient.so" "/usr/lib/x86_64-linux-gnu/steamclient.so" \
     && apt-get remove --purge -y \
         wget \
         curl \
@@ -64,8 +64,8 @@ RUN set -x \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p "${STEAM_APPDIR}" \
-	&& chmod 755 "${STEAM_APPDIR}" \
-	&& chown -R "${USER}:${USER}" "${STEAM_APPDIR}" 
+    && chmod 755 "${STEAM_APPDIR}" \
+    && chown -R "${USER}:${USER}" "${STEAM_APPDIR}" 
 
 RUN python3 -m pip install -U discord.py
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,6 @@ RUN set -x \
         wget \
     && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
     && dpkg-reconfigure --frontend=noninteractive locales \
-    && printenv \
     && useradd -u "${PUID}" -m "${USER}" \
     && su "${USER}" -c \
                 "mkdir -p \"${STEAMCMDDIR}\" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,8 @@ services:
         # - "2345:2345/tcp" # BattlEye - arma31.battleye.com 
     volumes:
       - './arma3:/arma3'
-      # Uncomment if you want to persistently store login data
+      # Uncomment if you want to persistently store login data, 
+      # ensure that it's owned by UID/GID 1000:1000
       # - './userdata:/home/steam/Steam'
     env_file: .env
     restart: unless-stopped


### PR DESCRIPTION
Changes base image from `cm2network/steamcmd` to `debian:buster-slim` due to issues with `debian:bullseye` and `steamcmd`.